### PR TITLE
Add `no_quote_replacement` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ keywords = ["compiler-runner","scripting","snippets"]
 
 license = "MIT"
 
+[features]
+no_quote_replacement = []
+
 [dependencies]
 easy-shortcuts = "0.3"
 lapp = "0.4"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -52,7 +52,7 @@ const KITCHEN_SINK: &str = "
 // Windows shell quoting is a mess, so we make single quotes
 // become double quotes in expressions
 pub fn quote(s: String) -> String {
-    if cfg!(windows) {
+    if cfg!(all(windows, not(feature = "no_quote_replacement"))) {
         s.replace("\'","\"")
     } else {
         s


### PR DESCRIPTION
This disables the quote replacement on Windows if it is enabled.

This also allows writing character literals on Windows.