### PR TITLE
Recompile snippet only if it's code has changed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,7 @@ fn main() {
         }
         let recompile = if bin.is_file(){
             let old_code = fs::read_to_string(bin.clone()).unwrap();
-             code.ne(&old_code)
+             code.ne(&old_code) && bin.with_extension(exe_suffix).is_file()
         } else {
             true
         };


### PR DESCRIPTION
If there is already an exact rust source file, that was already compiled, then we can just rerun it, without recompiling, this makes a big different for men on windows using msys2 (execution goes from ~0.4s to >0.1s) since the rust compiler and possibly forking processes on msys2 is relatively slow.